### PR TITLE
Prevent calling DOK-Lookup if no call is given

### DIFF
--- a/assets/js/sections/qso.js
+++ b/assets/js/sections/qso.js
@@ -651,7 +651,7 @@ $("#callsign").focusout(function() {
 
 				var $dok_select = $('#darc_dok').selectize();
 				var dok_selectize = $dok_select[0].selectize;
-				if (result.dxcc.adif == '230') {
+				if ((result.dxcc.adif == '230') && (($("#callsign").val().trim().length)>0)) {
 					$.get(base_url + 'index.php/lookup/dok/' + $('#callsign').val().toUpperCase(), function(result) {
 						if (result) {
 							dok_selectize.addOption({name: result});


### PR DESCRIPTION
Under very certain circumstances, the dok-lookup is called, when the call-field is empty.
This causes PHP-Errrors.

This patch prevents calling the lookup, if the field is empty