### PR TITLE
Enable concurrency, where session is ONLY readed afterwards

### DIFF
--- a/application/controllers/Api.php
+++ b/application/controllers/Api.php
@@ -404,6 +404,7 @@ class API extends CI_Controller {
 	/* ENDPOINT for Rig Control */
 
 	function radio() {
+		session_write_close();
 		header('Content-type: application/json');
 
 		$this->load->model('api_model');

--- a/application/controllers/Logbook.php
+++ b/application/controllers/Logbook.php
@@ -89,8 +89,8 @@ class Logbook extends CI_Controller {
         echo json_encode($return, JSON_PRETTY_PRINT);
     }
 
-	function json($tempcallsign, $temptype, $tempband, $tempmode, $tempstation_id = null)
-	{
+	function json($tempcallsign, $temptype, $tempband, $tempmode, $tempstation_id = null) {
+		session_write_close();
 		// Cleaning for security purposes
 		$callsign = $this->security->xss_clean($tempcallsign);
 		$type = $this->security->xss_clean($temptype);
@@ -317,6 +317,7 @@ class Logbook extends CI_Controller {
 	*
 	*/
 	function jsonlookupgrid($gridsquare, $type, $band, $mode) {
+		session_write_close();
 		$return = [
 			"workedBefore" => false,
 			"confirmed" => false,
@@ -403,6 +404,7 @@ class Logbook extends CI_Controller {
 	}
 
 	function jsonlookupdxcc($country, $type, $band, $mode) {
+		session_write_close();
 
 		$return = [
 			"workedBefore" => false,
@@ -501,6 +503,7 @@ class Logbook extends CI_Controller {
 	}
 
 	function jsonlookupcallsign($callsign, $type, $band, $mode) {
+		session_write_close();
 
 		// Convert - in Callsign to / Used for URL processing
 		$callsign = str_replace("-","/",$callsign);

--- a/application/controllers/Lookup.php
+++ b/application/controllers/Lookup.php
@@ -54,6 +54,7 @@ class Lookup extends CI_Controller {
 	}
 
 	public function scp() {
+		session_write_close();
 		if($_POST['callsign']) {
 			$uppercase_callsign = strtoupper($_POST['callsign']);
 		}
@@ -112,6 +113,7 @@ class Lookup extends CI_Controller {
 	}
 
 	public function dok($call) {
+		session_write_close();
 
 		if($call) {
 			$uppercase_callsign = strtoupper($call);

--- a/application/controllers/Qso.php
+++ b/application/controllers/Qso.php
@@ -583,13 +583,14 @@ class QSO extends CI_Controller {
 
    // Return Previous QSOs Made in the active logbook
    public function component_past_contacts() {
-    $this->load->model('logbook_model');
-    if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+	   if(!$this->user_model->authorize(2)) { $this->session->set_flashdata('notice', 'You\'re not allowed to do that!'); redirect('dashboard'); }
+	   $this->load->model('logbook_model');
+	   session_write_close();
 
-    $data['query'] = $this->logbook_model->last_custom('5');
+	   $data['query'] = $this->logbook_model->last_custom('5');
 
-    // Load view
-    $this->load->view('qso/components/previous_contacts', $data);
+	   // Load view
+	   $this->load->view('qso/components/previous_contacts', $data);
    }
 
    function check_locator($grid) {

--- a/application/controllers/Radio.php
+++ b/application/controllers/Radio.php
@@ -13,6 +13,7 @@
 			// user is not logged in
 			redirect('user/login');
 		}
+		session_write_close();
 		// load the view
 		$data['page_title'] = "Hardware Interfaces";
 
@@ -32,6 +33,7 @@
 			// user is not logged in
 			redirect('user/login');
 		}
+		session_write_close();
 
 		$this->load->model('cat');
 		$query = $this->cat->status();
@@ -92,6 +94,7 @@
 				"error" => "not_logged_in"
 			), JSON_PRETTY_PRINT);
 		} else {
+		session_write_close();
 
 			header('Content-Type: application/json');
 
@@ -213,6 +216,7 @@
 
 		$this->session->set_flashdata('message', 'Radio Profile Deleted');
 
+		session_write_close();
 		redirect('radio');
 
 	}


### PR DESCRIPTION
Speeds up lookup at live/post QSO.
session_write locks in default state asynchronous-requests (they're blocking each other).

Removed the lock, where we're only READING Session-Vars, but not setting at QSO-Pages