### PR TITLE
Apply qrz.com changes to visitor's map

### DIFF
--- a/application/controllers/Visitor.php
+++ b/application/controllers/Visitor.php
@@ -216,7 +216,7 @@ class Visitor extends CI_Controller {
 
 
 		// Get Confirmed LoTW & Paper Squares (non VUCC)
-		$query = $this->gridmap_model->get_band_confirmed('SAT', 'All', 'false', 'true', 'false', 'All', $logbooks_locations_array);
+		$query = $this->gridmap_model->get_band_confirmed('SAT', 'All', 'false', 'true', 'false', 'false', 'All', $logbooks_locations_array);
 
 
 		if ($query && $query->num_rows() > 0)
@@ -252,7 +252,7 @@ class Visitor extends CI_Controller {
 		}
 
 		// Get worked squares
-		$query = $this->gridmap_model->get_band('SAT', 'All', 'false', 'true', 'false', 'All', $logbooks_locations_array);
+		$query = $this->gridmap_model->get_band('SAT', 'All', 'false', 'true', 'false', 'false', 'All', $logbooks_locations_array);
 
 		if ($query && $query->num_rows() > 0)
 		{
@@ -286,7 +286,7 @@ class Visitor extends CI_Controller {
 			}
 		}
 
-		$query_vucc = $this->gridmap_model->get_band_worked_vucc_squares('SAT', 'All', 'false', 'true', 'false', 'All', $logbooks_locations_array);
+		$query_vucc = $this->gridmap_model->get_band_worked_vucc_squares('SAT', 'All', 'false', 'true', 'false', 'false', 'All', $logbooks_locations_array);
 
 		if ($query && $query_vucc->num_rows() > 0)
 		{
@@ -313,7 +313,7 @@ class Visitor extends CI_Controller {
 		}
 
 		// Confirmed Squares
-		$query_vucc = $this->gridmap_model->get_band_confirmed_vucc_squares('SAT', 'All', 'false', 'true', 'false', 'All', $logbooks_locations_array);
+		$query_vucc = $this->gridmap_model->get_band_confirmed_vucc_squares('SAT', 'All', 'false', 'true', 'false', 'false', 'All', $logbooks_locations_array);
 
 		if ($query && $query_vucc->num_rows() > 0)
 		{


### PR DESCRIPTION
With implementation of qrz.com QSL stuff the Gridmap_model has been changed to also accept qrz as argument. In commit https://github.com/magicbug/Cloudlog/pull/2792/commits/0ca43202645604b1409e69bc948df8c8fad32b5a of PR https://github.com/magicbug/Cloudlog/pull/2792 the Visitor controller has been forgotten to also being refactored to these changes. This fixes it and makes the visitor gridmap functional again.