### PR TITLE
Re-add POTA menu item to awards

### DIFF
--- a/application/views/interface_assets/header.php
+++ b/application/views/interface_assets/header.php
@@ -163,6 +163,8 @@
 								<div class="dropdown-divider"></div>
 								<a class="dropdown-item" href="<?php echo site_url('awards/rac'); ?>"><i class="fas fa-trophy"></i> <?php echo lang('menu_rac'); ?></a>
 								<div class="dropdown-divider"></div>
+								<a class="dropdown-item" href="<?php echo site_url('awards/pota'); ?>"><i class="fas fa-trophy"></i> <?php echo lang('menu_pota'); ?></a>
+								<div class="dropdown-divider"></div>
 								<a class="dropdown-item" href="<?php echo site_url('awards/sig'); ?>"><i class="fas fa-trophy"></i> <?php echo lang('menu_sig'); ?></a>
 								<div class="dropdown-divider"></div>
 								<a class="dropdown-item" href="<?php echo site_url('awards/sota'); ?>"><i class="fas fa-trophy"></i> <?php echo lang('menu_sota'); ?></a>


### PR DESCRIPTION
In commit https://github.com/magicbug/Cloudlog/pull/2808/commits/537a28540cc9fb369b7132dbcd4b893ebe351da5 / PR https://github.com/magicbug/Cloudlog/pull/2808 the POTA item in awards menu has been removed accidentally. This re-adds the menu item.